### PR TITLE
Fixed area for interface

### DIFF
--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -57,7 +57,7 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
              "dielectric const inside")        // must have ein = eout
             ("epsilon_out,E", value<double>(&eout)->default_value(80),
              "dielectric const outside")        // must have ein = eout
-            ("fraction_diameter,g", value<double>(&fraction_diameter)->default_value(1),
+            ("fraction_diameter,g", value<double>(&fraction_diameter)->default_value(0.04),
              "for interface discretization width")    // enter a perfect square
             ("thermostat_mass,Q", value<double>(&Q)->default_value(1.0), "thermostat mass")
             ("chain_length_real,L", value<unsigned int>(&chain_length_real)->default_value(5),
@@ -136,7 +136,8 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
       unitlength = saltion_diameter_in * 0.5;
       unittime = sqrt(unitmass * unitlength * pow(10.0,-7) * unitlength / unitenergy);
       scalefactor = epsilon_water * lB_water / unitlength;
-    	bx = sqrt(212/0.6022/salt_conc_in/bz);
+    	//bx = sqrt(212/0.6022/salt_conc_in/bz);
+      bx = 10.508;
     	by=bx;
     	if (mdremote.steps < 100000)		// minimum mdremote.steps is 20000
       		mdremote.hiteqm = 10000;

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -8,7 +8,7 @@ void INTERFACE::set_up(double salt_conc_in, double salt_conc_out, int salt_valen
   // useful combinations of different dielectric constants (inside and outside)
   em = 0.5 * (ein + eout);
   ed = (eout - ein) / (4 * pi);
-  
+
   // useful length scales signifying competition between electrostatics and entropy
   lB_in = (lB_water * epsilon_water / ein) / unitlength;
   lB_out = (lB_water * epsilon_water / eout) / unitlength;
@@ -32,48 +32,48 @@ void INTERFACE::set_up(double salt_conc_in, double salt_conc_out, int salt_valen
     inv_kappa_out = 0;
     mean_sep_out = 0;
   }
-  
+
   // simulation box size (in reduced units)
-  lx = bx;	
+  lx = bx;
   ly = by;
   lz = bz;
-    
+
   return;
 }
-  
+
 void INTERFACE::put_saltions_inside(vector<PARTICLE>& saltion_in, int pz, int nz, double concentration, double diameter, vector<PARTICLE>& ion)
 {
   // establish the number of inside salt ions first
-  // Note: salt concentration is the concentration of one kind of ions, so for total ions a factor of 2 needs to be multiplied. 
+  // Note: salt concentration is the concentration of one kind of ions, so for total ions a factor of 2 needs to be multiplied.
   // also the factor of 0.6 is there in order to be consistent with units.
-  
+
   double volume_box = lx*ly*lz;
   unsigned int total_nions_inside = int((concentration * 0.6022) * (volume_box * unitlength * unitlength * unitlength));
   if (total_nions_inside % pz !=0)
     total_nions_inside = total_nions_inside - (total_nions_inside % pz) + pz;
-  
+
   unsigned int total_pions_inside = abs(nz) * total_nions_inside / pz;
   unsigned int total_saltions_inside = total_nions_inside + total_pions_inside;
-  
+
   // express diameter in consistent units
   diameter = diameter / unitlength;
-  
+
   // distance of closest approach between the ion and the interface
   double r0_x = 0.5 * lx - 0.5 * diameter;
   double r0_y = 0.5 * ly - 0.5 * diameter;
   double r0_z = 0.5 * lz - 0.5 * diameter;
-  
-  // UTILITY ugsl;			// utility used for making initial configuration 
-  
+
+  // UTILITY ugsl;			// utility used for making initial configuration
+
   const gsl_rng_type * rnT;
   gsl_rng * rnr;
 
   rnT = gsl_rng_default;
   rnr = gsl_rng_alloc (rnT);
-  
+
   // unsigned long int s = 23897897;  // gsl_rng_uniform will eventually want a non-negative "long" integer
   gsl_rng_env_setup();
-  
+
   // if you want to start with the same initial configuration comment three lines below
   // else uncomment them. uncommenting will generate a new randomized distribution of salt ions every run
   // srand((time(0)));                // srand & time are built-in
@@ -114,41 +114,41 @@ void INTERFACE::put_saltions_inside(vector<PARTICLE>& saltion_in, int pz, int nz
 	  list_salt_ions_inside << "salt ions inside" << endl;
 	  for (unsigned int i = 0; i < saltion_in.size(); i++)
 		list_salt_ions_inside << "Si" << setw(15) << saltion_in[i].posvec << endl;
-	  list_salt_ions_inside.close(); 
+	  list_salt_ions_inside.close();
   }
   gsl_rng_free (rnr);
-  
+
   return;
-} 
+}
 
 // discretize interface
 void INTERFACE::discretize(double ion_diameter, double f)
 {
   // width of the discretization (f is typically 1 or 1/2 or 1/4 or 1/8 ...)
-  width = f * ion_diameter;	// in reduced units
-  
+  width = f * lx;	// in reduced units
+
   // note lx and ly are in units of unitlength; that is they are reduced
-  unsigned int nx = int(lx / width);
-  unsigned int ny = int(ly / width);
-  
+  unsigned int nx = int(lx / width) + 1;
+  unsigned int ny = int(ly / width) + 1;
+
   // creating a discretized hard wall interface at z = - l/2
   for (unsigned int j = 0; j < ny; j++)
   {
     for (unsigned int i = 0; i < nx; i++)
     {
-      VECTOR3D position = VECTOR3D(-0.5*lx+0.5*width+i*width,-0.5*ly+0.5*width+j*width,-0.5*lz);
+      VECTOR3D position = VECTOR3D(-0.5*lx+i*width,-0.5*ly+j*width,-0.5*lz);
       double area = width * width;
       VECTOR3D normal = VECTOR3D(0,0,-1);
       leftplane.push_back(VERTEX(position,area,normal));
     }
   }
-  
+
   // creating a discretized hard wall interface at z = l/2
   for (unsigned int j = 0; j < ny; j++)
   {
     for (unsigned int i = 0; i < nx; i++)
     {
-      VECTOR3D position = VECTOR3D(-0.5*lx+0.5*width+i*width,-0.5*ly+0.5*width+j*width,0.5*lz);
+      VECTOR3D position = VECTOR3D(-0.5*lx+i*width,-0.5*ly+j*width,0.5*lz);
       double area = width * width;
       VECTOR3D normal = VECTOR3D(0,0,1);
       rightplane.push_back(VERTEX(position,area,normal));
@@ -169,10 +169,10 @@ void INTERFACE::discretize(double ion_diameter, double f)
 	  listleftplane << -0.5*ly << "\t" << 0.5*ly << endl;
 	  listleftplane << -0.5*lz << "\t" << 0.5*lz << endl;
 	  listleftplane << "ITEM: ATOMS index type x y z" << endl;
-	  for (unsigned int k = 0; k < leftplane.size(); k++) 
+	  for (unsigned int k = 0; k < leftplane.size(); k++)
 		listleftplane << k+1 << "  " << "1" << "  " << leftplane[k].posvec << endl;
-	  listleftplane.close();  
-	  
+	  listleftplane.close();
+
 	  string listrightplanePath= rootDirectory+"outfiles/rightplane.xyz";
 	  ofstream listrightplane(listrightplanePath.c_str(), ios::out);
 	  listrightplane << "ITEM: TIMESTEP" << endl;
@@ -184,9 +184,9 @@ void INTERFACE::discretize(double ion_diameter, double f)
 	  listrightplane << -0.5*ly << "\t" << 0.5*ly << endl;
 	  listrightplane << -0.5*lz << "\t" << 0.5*lz << endl;
 	  listrightplane << "ITEM: ATOMS index type x y z" << endl;
-	  for (unsigned int k = 0; k < rightplane.size(); k++) 
+	  for (unsigned int k = 0; k < rightplane.size(); k++)
 		listrightplane << k+1 << "  " << "1" << "  " << rightplane[k].posvec << endl;
-	  listrightplane.close();  
+	  listrightplane.close();
   }
   return;
 }


### PR DESCRIPTION
@jadhao
I changed "interface.cpp" and "NanoconfinementMd.cpp" to create a fixed interface which completely covers the xy plane. 
In original code, the surface area (bx and by)  is changed according to concentration but the number of ions is fixed (424). In this code, the surface area is fixed (bx=by=10.508 nm), but the number of particles is changing depending on the values of concentration. 
I checked their kinetic and potential energies and the density profiles. They have the same density profile, the energies are conserved but the values of kinetic and potential energies in this case are less than the original code.