### PR TITLE
Remove Dummy Wall

### DIFF
--- a/src/mdenergies.cpp
+++ b/src/mdenergies.cpp
@@ -232,8 +232,9 @@ long double energy_functional(vector <PARTICLE> &ion, INTERFACE &box, unsigned i
     total_lj_ion_ion = 0.5 * total_lj_ion_ion;
     // factor of half for double counting, same reasoning as electrostatic energy
 
-    potential = coulomb + total_lj_ion_ion + total_lj_ion_leftdummy + total_lj_ion_leftwall
-                       + total_lj_ion_rightdummy + total_lj_ion_rightwall;
+  //  potential = coulomb + total_lj_ion_ion + total_lj_ion_leftdummy + total_lj_ion_leftwall
+  //                     + total_lj_ion_rightdummy + total_lj_ion_rightwall;
+    potential = coulomb + total_lj_ion_ion + total_lj_ion_leftwall + total_lj_ion_rightwall;
 
     //MPI Operations
     if (world.size() > 1) {
@@ -247,4 +248,3 @@ long double energy_functional(vector <PARTICLE> &ion, INTERFACE &box, unsigned i
 
     return totalPotential;
 }
-

--- a/src/mdforces.cpp
+++ b/src/mdforces.cpp
@@ -228,8 +228,9 @@ void for_md_calculate_force(vector <PARTICLE> &ion, INTERFACE &box, char flag, u
 
         // total force on the particle = the electrostatic force + the Lennard-Jones force slave processes
         for (i = 0; i < sendForceVector.size(); i++) {
-            sendForceVector[i] = sendForceVector[i] + lj_ion_ion[i] + lj_ion_leftdummy[i] +
-                                 lj_ion_left_wall[i] + lj_ion_rightdummy[i] + lj_ion_right_wall[i];
+        //    sendForceVector[i] = sendForceVector[i] + lj_ion_ion[i] + lj_ion_leftdummy[i] +
+        //                         lj_ion_left_wall[i] + lj_ion_rightdummy[i] + lj_ion_right_wall[i];
+            sendForceVector[i] = sendForceVector[i] + lj_ion_ion[i] + lj_ion_left_wall[i]+ lj_ion_right_wall[i];
         }
 
         //broadcasting using all gather = gather + broadcast
@@ -245,10 +246,12 @@ void for_md_calculate_force(vector <PARTICLE> &ion, INTERFACE &box, char flag, u
 
         // total force on the particle = the electrostatic force + the Lennard-Jones force in main processes
         for (i = lowerBound; i <= upperBound; i++)
+        //    ion[i].forvec =
+        //            sendForceVector[i - lowerBound] + lj_ion_ion[i - lowerBound] + lj_ion_leftdummy[i - lowerBound] +
+        //            lj_ion_left_wall[i - lowerBound] + lj_ion_rightdummy[i - lowerBound] +
+        //            lj_ion_right_wall[i - lowerBound];
             ion[i].forvec =
-                    sendForceVector[i - lowerBound] + lj_ion_ion[i - lowerBound] + lj_ion_leftdummy[i - lowerBound] +
-                    lj_ion_left_wall[i - lowerBound] + lj_ion_rightdummy[i - lowerBound] +
-                    lj_ion_right_wall[i - lowerBound];
+                    sendForceVector[i - lowerBound] + lj_ion_ion[i - lowerBound] + lj_ion_left_wall[i - lowerBound] + lj_ion_right_wall[i - lowerBound];
 
     }
 


### PR DESCRIPTION
@jadhao
Left and right dummy walls are removed from energy and force calculations. The energy values are converged and comparable with energy values in example folder.