### PR TITLE
Change the salt concentration definition & make negative ion dia

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -4,29 +4,30 @@ JOBSCR = nanoconfinement.pbs
 TEST = test.pbs
 JOBSCRLMP = nanoconfinement-lammps.pbs
 Z=3
-p=1 
+p=1
 n=-1
 c=0.5
 d=0.714
+a=0.714
 S=5000000
 NODESIZE=4
 
-submit: 
+submit:
 	@echo "Launching the job";
 	qsub $(JOBSCR)
 
-test: 
+test:
 	@echo "Launching the test job for nanoconfinement-md";
 	qsub $(TEST)
-	
+
 
 run-preprocessor:
-	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -S $(S) -J true -j true
-	
-run-postprocessor:
-	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -S $(S) -J true -j false
+	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -a $(a) -S $(S) -J true -j true
 
-submit-lammps: 
+run-postprocessor:
+	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -a $(a) -S $(S) -J true -j false
+
+submit-lammps:
 	@echo "Launching the job for Lammps script";
 	qsub $(JOBSCRLMP)
 

--- a/bin/input_config.cfg
+++ b/bin/input_config.cfg
@@ -2,5 +2,6 @@ confinement_length = 3
 positive_valency = 1
 negative_valency = -1
 salt_concentration = 0.5
-ion_diameter = 0.714
+positive_diameter = 0.714
+negative_diameter = 0.714
 simulation_steps = 1000000

--- a/docs/cluster_bigred2_deployment.md
+++ b/docs/cluster_bigred2_deployment.md
@@ -8,10 +8,10 @@ summary: This page has instructions to install the source code for simulating io
 
 ## Installing from Source and Building on IU BigRed2
 
-The nanoconfinement code is open source and can optionally be built from source and used locally or on computer clusters. The following cluster build instructions should serve as a reference. 
+The nanoconfinement code is open source and can optionally be built from source and used locally or on computer clusters. The following cluster build instructions should serve as a reference.
 
 ### Necessary Modules
-* By default BR2 cluster environment has Cray programming environment module (PrgEnv-cray) loaded 
+* By default BR2 cluster environment has Cray programming environment module (PrgEnv-cray) loaded
 * Nanoconfinement code has dependency to Boost libraries which requires GNU programming environment
     * Switch modules to GNU - ```module swap PrgEnv-cray PrgEnv-gnu```
 * Load latest boost libraries
@@ -20,7 +20,7 @@ The nanoconfinement code is open source and can optionally be built from source 
     * ```module load gsl```
 
 ### Install instructions
-* Copy or git clone nanoconfinement-md project in to a directory. 
+* Copy or git clone nanoconfinement-md project in to a directory.
 * Go to nanoconfinement-md directory and (cd nanoconfinement-md)
 * You should provide the following make command to make the project. This will create the executable and Install the executable (md_simulation_confined_ions) into bin directory (That is nanoconfinement-md/bin)
     * make cluster-install
@@ -33,8 +33,8 @@ The nanoconfinement code is open source and can optionally be built from source 
     * cd nanoconfinement-md/bin
 * Load the modules using following command :
     * module swap PrgEnv-cray PrgEnv-gnu && module load boost/1.65.0 && module load gsl
-* execute the program using following command : 
-    * time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -S 1000000
+* execute the program using following command :
+    * time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -S 1000000
 
 #### Using a jobscript
 * If you need to change the computational parameter or the physical parameters, you may edit the jobscript file.

--- a/scripts/nanoconfinement.pbs
+++ b/scripts/nanoconfinement.pbs
@@ -17,4 +17,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=16
 # the following is a test simulation to check things are working, it simulates 0.1 M of +1 and -1 ions of diameter 0.714 nm confined within 3 nm
 # -d refers to number of cores. this should match ppn in Line 2.
-time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -S 1000000
+time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -S 1000000

--- a/scripts/test.pbs
+++ b/scripts/test.pbs
@@ -17,4 +17,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=16
 # the following is a test simulation to check things are working, it simulates 0.1 M of +1 and -1 ions of diameter 0.714 nm confined within 3 nm
 # -d refers to number of cores. this should match ppn in Line 2.
-time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -S 100000
+time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -S 100000

--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -89,8 +89,10 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
             ("positive_valency,p", value<int>(&pz_in)->default_value(1), "positive valency inside")
             ("negative_valency,n", value<int>(&nz_in)->default_value(-1), "negative valency inside")
             ("salt_concentration,c", value<double>(&salt_conc_in)->default_value(0.50), "salt concentration inside")
-            ("ion_diameter,d", value<double>(&positive_diameter_in)->default_value(0.714),
-             "salt ion diameter inside")        // enter in nanometers
+            ("positive_diameter,d", value<double>(&positive_diameter_in)->default_value(0.714),
+             "positive ion diameter inside")        // enter in nanometers
+             ("negative_diameter,a", value<double>(&negative_diameter_in)->default_value(0.714),
+              "negative ion diameter inside")        // enter in nanometers
             ("simulation_steps,S", value<int>(&mdremote.steps)->default_value(5000000), "steps used in md")
             ("lammps,J", value<bool>(&lammps)->default_value(false), "LAMMPS (true LAMMPS; false MD)")
             ("lammpsPreprocessing,j", value<bool>(&lammpsPreprocessing)->default_value(true), "LAMMPS Preprocessing/Postprocessing (true Preprocessing; false Postprocessing)");
@@ -131,7 +133,7 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
     }
     //X and Y mapping
     if (paraMap) {
-        negative_diameter_in = 0.714;
+      //  negative_diameter_in = 0.714;
         unitlength = positive_diameter_in;
         unittime = sqrt(unitmass * unitlength * pow(10.0, -7) * unitlength / unitenergy);
         scalefactor = epsilon_water * lB_water / unitlength;

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -48,11 +48,15 @@ void INTERFACE::put_saltions_inside(vector<PARTICLE>& saltion_in, int pz, int nz
   // also the factor of 0.6 is there in order to be consistent with units.
 
   double volume_box = lx*ly*lz;
-  unsigned int total_nions_inside = int((concentration * 0.6022) * (volume_box * unitlength * unitlength * unitlength));
-  if (total_nions_inside % pz !=0)
-    total_nions_inside = total_nions_inside - (total_nions_inside % pz) + pz;
+//  unsigned int total_nions_inside = int((concentration * 0.6022) * (volume_box * unitlength * unitlength * unitlength));
+//  if (total_nions_inside % pz !=0)
+//    total_nions_inside = total_nions_inside - (total_nions_inside % pz) + pz;
 
-  unsigned int total_pions_inside = abs(nz) * total_nions_inside / pz;
+//  unsigned int total_pions_inside = abs(nz) * total_nions_inside / pz;
+//  unsigned int total_saltions_inside = total_nions_inside + total_pions_inside;
+
+  unsigned int total_pions_inside = int((concentration * 0.6022) * (volume_box * unitlength * unitlength * unitlength));
+    unsigned int total_nions_inside = total_pions_inside * pz;
   unsigned int total_saltions_inside = total_nions_inside + total_pions_inside;
 
   // express diameter in consistent units


### PR DESCRIPTION
@jadhao 
@kadupitiya 
- I changed the salt concentration definition based on positive ions.
- The negative ion diameter is now a variable that user can inter the value.
-  I tested the simulation (for 1ns), for 0.714_0.714_1-1_0.5_3 and 0.714_0.357_1-1_0.5_3. The output has not changed comparing to master.
- I also did the simulation for  0.357_0.714_1-1_0.5_3 and compare it with  0.714_0.357_1-1_0.5_3. There is a slight difference between them, because the unit length has changed (it is equal to positive ion diameter). So, the bin size will change according to unit length.