### PR TITLE
uncharged surface ( with in-house and lammps) and charged surface (with lammps)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# make cluster-submit-lammps Z=3 p=1 n=-1 c=0.5 d=0.714 a=0.714 S=5000000
-# make local-run-lammps Z=3 p=1 n=-1 c=0.5 d=0.714 a=0.714 S=5000000 MPIRUNCMD=mpirun
+# make cluster-submit-lammps Z=3 p=1 n=-1 c=0.5 d=0.714 a=0.714 i=0.0 S=5000000
+# make local-run-lammps Z=3 p=1 n=-1 c=0.5 d=0.714 a=0.714 i=0.0 S=5000000 MPIRUNCMD=mpirun
 #This make file builds the sub folder make files
 PROG = md_simulation_confined_ions
 JOBSCR = nanoconfinement.pbs
@@ -11,11 +11,12 @@ BASE = src
 SCRIPT = scripts
 
 Z=3
-p=1 
+p=1
 n=-1
 c=0.5
 d=0.714
 a=0.714
+i=0.0
 S=5000000
 NODESIZE=4
 
@@ -24,7 +25,7 @@ LAMMPSEXE = lmp_mpi
 
 all:
 	@echo "Starting build of the $(BASE) directory";
-ifeq ($(CCF),BigRed2)	
+ifeq ($(CCF),BigRed2)
 	+$(MAKE) -C $(BASE) cluster-install
 else ifeq ($(CCF),nanoHUB)
 	+$(MAKE) -C $(BASE) install
@@ -35,7 +36,7 @@ endif
 	@echo "installing the $(PROG) into $(BIN) directory"; cp -f $(BASE)/$(PROG) $(BIN)
 
 local-install: create-dirs
-	make CCF=LOCAL all	
+	make CCF=LOCAL all
 
 cluster-install: create-dirs
 	make CCF=BigRed2 all
@@ -60,35 +61,35 @@ cluster-test-submit:
 	@echo "Installing test jobscript into $(BIN) directory"
 	cp -f $(SCRIPT)/$(TEST) $(BIN)
 	+$(MAKE) -C $(BIN) test
-	
+
 cluster-submit-lammps:
 	@echo "Running the preprocessor to create lammps script and input script."
-	+$(MAKE) -C $(BIN) run-preprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) S=$(S)
+	+$(MAKE) -C $(BIN) run-preprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) i=$(i) S=$(S)
 	@echo "Running the preprocessor is over."
 	@echo "Installing jobscript into $(BIN) directory"
 	cp -f $(SCRIPT)/$(JOBSCRLMP) $(BIN)
 	+$(MAKE) -C $(BIN) submit-lammps
-	
+
 run-postprocessor:
-	+$(MAKE) -C $(BIN) run-postprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
+	+$(MAKE) -C $(BIN) run-postprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) i=$(i) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
 	@echo "Postprocessing is over."
 
 local-run-parallel-lammps:
 	@echo "Running the preprocessor to create lammps script and input script."
-	+$(MAKE) -C $(BIN) run-preprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) S=$(S) MPIRUNCMD=$(MPIRUNCMD) 
+	+$(MAKE) -C $(BIN) run-preprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) i=$(i) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
 	@echo "Running the preprocessor is over."
 	+$(MAKE) -C $(BIN) run-local-parallel NODESIZE=$(NODESIZE) MPIRUNCMD=$(MPIRUNCMD) LAMMPSEXE=$(LAMMPSEXE)
 	@echo "Lammps simulation is over."
-	+$(MAKE) -C $(BIN) run-postprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) S=$(S) MPIRUNCMD=$(MPIRUNCMD) 
+	+$(MAKE) -C $(BIN) run-postprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) i=$(i) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
 	@echo "Postprocessing is over."
 
 local-run-lammps:
 	@echo "Running the preprocessor to create lammps script and input script."
-	+$(MAKE) -C $(BIN) run-preprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
+	+$(MAKE) -C $(BIN) run-preprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) i=$(i) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
 	@echo "Running the preprocessor is over."
 	+$(MAKE) -C $(BIN) run-local-serial LAMMPSEXE=$(LAMMPSEXE)
 	@echo "Lammps simulation is over."
-	+$(MAKE) -C $(BIN) run-postprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
+	+$(MAKE) -C $(BIN) run-postprocessor Z=$(Z) p=$(p) n=$(n) c=$(c) d=$(d) a=$(a) i=$(i) S=$(S) MPIRUNCMD=$(MPIRUNCMD)
 	@echo "Postprocessing is over."
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ What does this code do
 * The code enables simulations of ions confined between nanoparticles (NPs) or other material surfaces
     * Length of confinement is of the order of nanometers
 * Materials represent nanoparticles (NPs) or biomacromolecules
-    * NP surfaces are treated as planar walls due to the large size difference between ions and NPs 
+    * NP surfaces are treated as planar walls due to the large size difference between ions and NPs
 * Users can extract the ionic structure (density profile) for a wide variety of ionic and environmental parameters
 * Unpolarized surfaces are assumed and standard molecular dynamics is used to propagrate the dynamics of ions
 
@@ -20,18 +20,20 @@ Install instructions
 * Go to nanoconfinement-md directory and (cd nanoconfinement-md)
 * You should provide the following make command to make the project. This will create the executable and Install the executable (md_simulation_confined_ions) into bin directory (That is nanoconfinement-md/bin)
    * make local-install
-* Next, go to the bin directory: cd bin
 
-* In bin directory, you have two options to run the simulation. You can run the simulation through eighter the in-house code or the LAMMPS. The difference between these two options is the method that we use to calculate the electrostatics energy and force. In in-house code, we calculate the electrostatics energy and force with "charged sheet method". In LAMMPS, the electrostatics energy and force are calculated with Ewald-Summation method. 
-  
+* Now, you have two options to run the simulation. You can run the simulation through the in-house code or the LAMMPS. The difference between these two options is the method that we use to calculate the electrostatics energy and force. In in-house code, we calculate the electrostatics energy and force with "charged sheet method". In LAMMPS, the electrostatics energy and force are calculated with Ewald-Summation method.
+
 Run the simulation through the in-house code:
 
-* Now you are ready to run the executable with aprun command using the following method: time mpirun -np 2 -N 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -S 1000000
+* go to the bin directory: cd bin
+
+* Now you are ready to run the executable with aprun command using the following method: time mpirun -np 2 -N 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -i 0.0 -S 1000000
+* Note that in current in-house code, you are only able to simulate a system with uncharged surfaces (-i 0.0).
 
 Run the simulation through the LAMMPS:
 
-* The command to execute the LAMMPS is: make local-run-lammps Z=3 p=1 n=-1 c=0.5 d=0.714 a=0.714 S=1000000 MPIRUNCMD=mpirun LAMMPSEXE=lmp
-* This make command creates the input data file (ip.lammps.xyz) through the inhouse code. Then it runs the simulation with LAMMPS.
+* In nanoconfinement-md directory, the command to execute the LAMMPS is: make local-run-lammps Z=3 p=1 n=-1 c=0.5 d=0.714 a=0.714 i=0.0 S=1000000 MPIRUNCMD=mpirun LAMMPSEXE=lmp
+* This make command creates the input data file (ip.lammps.xyz) through the inhouse code. Then it runs the simulation with LAMMPS. In LAMMPS, you can define charge on the surfaces. For uncharged surfaces: i=0.0. For charged surfaces, you can choose i between zero to -0.01 C/m2. The simulation does not work with charge density more than zero or less than -0.01 C/m-2. 
 
 * All outputs from the simulation will be stored in the bin folder when the simulation is completed.
    * Check and compare files (ex: energy.out) inside the bin/outfiles directory.
@@ -39,7 +41,7 @@ Run the simulation through the LAMMPS:
    * Once the simulation has finished, data and outflies folders will contain the simulation results. You may check final density profile form data folder against the example desity profile provided in nanoconfinement-md/examples folder.
 
 
-For further details please refer to the [documentation](https://softmaterialslab.github.io/nanoconfinement-md/) 
+For further details please refer to the [documentation](https://softmaterialslab.github.io/nanoconfinement-md/)
 
 ## NanoHUB app page:
 * https://nanohub.org/tools/nanoconfinement

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -10,6 +10,7 @@ n=-1
 c=0.5
 d=0.714
 a=0.714
+i=0.0
 S=5000000
 NODESIZE=4
 
@@ -23,10 +24,10 @@ test:
 
 
 run-preprocessor:
-	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -a $(a) -S $(S) -J true -j true
+	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -a $(a) -S $(S) -i $(i) -J true -j true
 
 run-postprocessor:
-	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -a $(a) -S $(S) -J true -j false
+	$(MPIRUNCMD) -n 1 md_simulation_confined_ions -Z $(Z) -p $(p) -n $(n) -c $(c) -d $(d) -a $(a) -S $(S) -i $(i) -J true -j false
 
 submit-lammps:
 	@echo "Launching the job for Lammps script";

--- a/bin/input_config.cfg
+++ b/bin/input_config.cfg
@@ -4,4 +4,5 @@ negative_valency = -1
 salt_concentration = 0.5
 positive_diameter = 0.714
 negative_diameter = 0.714
+chargedensity_surface = 0.0
 simulation_steps = 1000000

--- a/scripts/nanoconfinement.pbs
+++ b/scripts/nanoconfinement.pbs
@@ -17,4 +17,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=16
 # the following is a test simulation to check things are working, it simulates 0.1 M of +1 and -1 ions of diameter 0.714 nm confined within 3 nm
 # -d refers to number of cores. this should match ppn in Line 2.
-time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -S 1000000
+time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -i 0.0 -S 1000000

--- a/scripts/test.pbs
+++ b/scripts/test.pbs
@@ -17,4 +17,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=16
 # the following is a test simulation to check things are working, it simulates 0.1 M of +1 and -1 ions of diameter 0.714 nm confined within 3 nm
 # -d refers to number of cores. this should match ppn in Line 2.
-time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -S 100000
+time aprun -n 4 -d 16 ./md_simulation_confined_ions -Z 3 -p 1 -n -1 -c 0.5 -d 0.714 -a 0.714 -i 0.0 -S 100000


### PR DESCRIPTION
@jadhao and @kadupitiya 

In both lammps and in-house, I added **i** as a variable in command to the run the simulation: 
- In in-house, the user can only choose -i 0.0 since the in-house simulates the uncharged surfaces.
-In lammps, they can choose i=0.0 to i=-0.01 to simulate charged and uncharged surfaces.
-README is updated. 