### PR TITLE
Symmetrical bin discretization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ clean: dataclean
 	rm -rf $(BIN)/outfiles
 	rm -rf $(BIN)/data
 	rm -f $(BIN)/*.lammps
+	rm -f $(BIN)/temp
 
 dataclean:
 	rm -f $(BIN)/outfiles/*.dat $(BIN)/outfiles/*.xyz  $(BIN)/outfiles/*.lammpstrj  $(BIN)/temp/*

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,6 +66,7 @@ clean: dataclean
 	rm -rf $(BIN)/outfiles/*
 	rm -rf $(BIN)/data/*
 	rm -f $(BIN)/*.lammps
+	rm -f $(BIN)/temp
 
 dataclean:
 	rm -f $(BIN)/outfiles/*.dat $(BIN)/outfiles/*.xyz  $(BIN)/outfiles/*.lammpstrj  $(BIN)/temp/*

--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -23,17 +23,17 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
     double salt_conc_in;        // salt concentration outside	(enter in M)
     double positive_diameter_in;    // positive ion diameter
     double negative_diameter_in;   // negative ion diameter
-    double counterion_diameter_in; // counterion ion diameter; (counterion ions assumed to be positive diameter and surfaces are negatively charged)
+    double counterion_diameter_in = 0.0; // counterion ion diameter; (counterion ions assumed to be positive diameter and surfaces are negatively charged)
     double T;            // temperature at which the system of ions is
-    double charge_meshpoint; // charge on mesh points to create uniform charge density on surface
+    double charge_meshpoint = 0.0; // charge on mesh points to create uniform charge density on surface
     double charge_density; // charge density on surface
     int valency_counterion;
-    unsigned int counterions;         //number of counter ions
-    double total_surface_charge; //total charge on the surface (in unit of electron charge)
-    double surface_area; // area of surface
-    double number_meshpoints; // number of mesh points on the surface
-    double smaller_ion_diameter; // the salt ion with smaller size;
-    double bigger_ion_diameter; // the salt ion with bigger size;
+    unsigned int counterions = 0.0;         //number of counter ions
+    double total_surface_charge = 0.0; //total charge on the surface (in unit of electron charge)
+    double surface_area = 0.0; // area of surface
+    double number_meshpoints = 0.0; // number of mesh points on the surface
+    double smaller_ion_diameter = 0.0; // the salt ion with smaller size;
+    double bigger_ion_diameter = 0.0; // the salt ion with bigger size;
 
 
     // Simulation related variables
@@ -129,7 +129,7 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
           return 0;
         }
 	 }
-	 
+
     if (world.rank() == 0) {
         if (mdremote.verbose) {
             cout << "For help with the menu, type ./md_simulation_confined_ions -h" << endl;
@@ -392,7 +392,6 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
                     cout << "Number of samples used to get density profile:" << cnt_filename << endl;
                 int lammps_samples = cnt_filename;
               //  make_bins(bin, box, bin_width);    // set up bins to be used for computing density profiles
-                int cpmdstep = 0;
                 double lammps_density_profile_samples = 0;
                 for (int cpmdstep = 0; cpmdstep < lammps_samples; cpmdstep++) {
                     vector <PARTICLE> ion;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -11,6 +11,7 @@ ostream &operator<<(ostream &os, VECTOR3D vec) {
 // make bins
 void make_bins(vector<DATABIN> &bin, INTERFACE &box, double bin_width) {
     int number_of_bins = int(box.lz / bin_width);
+    bin_width = (box.lz / number_of_bins); // To make discretization of bins symmetric, we recalculate the bin_width
     /*Add two extra bins for contact point densities at both ends*/
     number_of_bins += 2;
     bin.resize(number_of_bins);
@@ -293,9 +294,9 @@ void output_lammps(vector<PARTICLE> &ion, int &cnt_filename, double data_frequen
     VECTOR3D posvec;
     string AtomType, ChargeType, Num, line;
     cnt_filename = 0;
-    int j = 0;
+    unsigned int j = 0;
     int filenumber = 0;
-    int header = 9; // There are 9 lines before the atom coordinates start.
+    unsigned int header = 9; // There are 9 lines before the atom coordinates start.
     char filename[100];
     ifstream file;
 


### PR DESCRIPTION
@jadhao and @ kadupitiya
- In function.cpp, the bin-width is recalculated to make symmetrical bin discretization.
- For warning issues ("may be used uninitialized in this function"), in nanoconfinement.cpp, I initialized the variables (like counterions, total_surface_charge, charge_meshpoint) to be zero. But for some variables like surface_area, I'm not sure if it is a good idea to initialize it to be zero.  