### PR TITLE
add charge on vertex

### DIFF
--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -223,7 +223,7 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
     vector<double> initial_density;
     bin_ions(ion, box, initial_density, bin);    // bin the ions to get initial density profile
 
-    box.discretize(smaller_ion_diameter / unitlength, fraction_diameter);
+    box.discretize(smaller_ion_diameter / unitlength, fraction_diameter, charge_meshpoint);
 
     if (world.rank() == 0) {
         // output to screen the parameters of the problem

--- a/src/interface.h
+++ b/src/interface.h
@@ -52,6 +52,7 @@ class INTERFACE
   double inv_kappa_out;		// debye length outside
   double mean_sep_in;		// mean separation inside
   double mean_sep_out;		// mean separation outside
+  double meshpoint;		// charge of the meshpoint
 
   double width;			// discretization width
   vector<VERTEX> leftplane;
@@ -59,8 +60,9 @@ class INTERFACE
 
   void set_up(double, double, int, int, double, double, double);
   void put_saltions_inside(vector<PARTICLE>&, int, int, double, double, double, vector<PARTICLE>&, unsigned int, int, double, double);
-  void discretize(double, double);
+  void discretize(double, double, double);
   void generate_lammps_datafile(vector<PARTICLE>&, int, int, vector<PARTICLE>&, double, double, int, int, double, double);
+  double electrostatics_between_walls(double);
 
   INTERFACE(VECTOR3D initial_posvec = VECTOR3D(0,0,0), double initial_ein = 1, double initial_eout = 1)
   {

--- a/src/mdenergies.cpp
+++ b/src/mdenergies.cpp
@@ -12,7 +12,7 @@ long double energy_functional(vector <PARTICLE> &ion, INTERFACE &box, unsigned i
 
 	mpi::environment env;
 	mpi::communicator world;
-    unsigned int i, j, k, m, l, b;
+    unsigned int i, j, k, m;
     double fqq, fqq_csh, fqq_rightwall, fqq_leftwall, fqq_csh_leftwall,fqq_csh_rightwall;
     double fcsh_z, r1, r2, dz, fcsh_inf, dz_rightwall, r1_rightwall, r2_rightwall,dz_leftwall, r1_leftwall, fcsh_inf_rightwall, fcsh_z_rightwall, r2_leftwall, fcsh_z_leftwall, fcsh_inf_leftwall;
     VECTOR3D temp_vec, temp_vec_rightwall, temp_vec_leftwall;
@@ -211,84 +211,71 @@ long double energy_functional(vector <PARTICLE> &ion, INTERFACE &box, unsigned i
 //            lj_ion_rightwall[i-lowerBound] = ulj;
 //        }
 //    }
-//coulomb interaction ion-rightwall///////////////////////////////////////////////////////////////////////////
-#pragma omp parallel default(shared) private(i, k, wall_dummy, fqq_rightwall, fqq_csh_rightwall, dz_rightwall , r1_rightwall, r2_rightwall, fcsh_inf_rightwall, fcsh_z_rightwall, temp_vec_rightwall)
+
+if (charge_meshpoint != 0.0) // if charge_mesh is not zero, there is electrostatics interaction between ions and walls;
 {
-#pragma omp for schedule(dynamic) nowait
-  for (i = lowerBound; i <= upperBound; i++)
+  //coulomb interaction ion-rightwall///////////////////////////////////////////////////////////////////////////
+  #pragma omp parallel default(shared) private(i, k, wall_dummy, fqq_rightwall, fqq_csh_rightwall, dz_rightwall , r1_rightwall, r2_rightwall, fcsh_inf_rightwall, fcsh_z_rightwall, temp_vec_rightwall)
   {
-    fqq_rightwall = 0;
-    fqq_csh_rightwall = 0;
-    for (k = 0; k < box.rightplane.size(); k++) {
-      wall_dummy = PARTICLE(0, 0, valency_counterion * -1, charge_meshpoint * 1.0, 0, box.eout, VECTOR3D(box.rightplane[k].posvec.x, box.rightplane[k].posvec.y, box.rightplane[k].posvec.z), box.lx, box.ly, box.lz);
-      dz_rightwall  = ion[i].posvec.z - wall_dummy.posvec.z;
-      r1_rightwall = sqrt(0.5 + (dz_rightwall  / box.lx) * (dz_rightwall  / box.lx));
-      r2_rightwall = sqrt(0.25 + (dz_rightwall  / box.lx) * (dz_rightwall  / box.lx));
-      fcsh_z_rightwall = 4 * box.lx * log((0.5 + r1_rightwall) / r2_rightwall) - fabs(dz_rightwall) * (2 * pi - 4 * atan(4 * fabs(dz_rightwall ) * r1_rightwall / box.lx));
-      fcsh_inf_rightwall = -2 * pi * fabs(dz_rightwall);
-      fqq_csh_rightwall += ion[i].q * (wall_dummy.q / (box.lx * box.lx)) * 0.5 * (1 / ion[i].epsilon + 1 / wall_dummy.epsilon) * (fcsh_inf_rightwall - fcsh_z_rightwall);
-
-      temp_vec_rightwall = ion[i].posvec - wall_dummy.posvec;
-      if (temp_vec_rightwall.x > box.lx / 2) temp_vec_rightwall.x -= box.lx;
-      if (temp_vec_rightwall.x < -box.lx / 2) temp_vec_rightwall.x += box.lx;
-      if (temp_vec_rightwall.y > box.ly / 2) temp_vec_rightwall.y -= box.ly;
-      if (temp_vec_rightwall.y < -box.ly / 2) temp_vec_rightwall.y += box.ly;
-
-      fqq_rightwall += ion[i].q * wall_dummy.q * 0.5 * (1.0 / ion[i].epsilon + 1.0 / wall_dummy.epsilon) / ((temp_vec_rightwall).GetMagnitude());
-
-    }
-    coulomb_rightwall[i-lowerBound] = fqq_rightwall + fqq_csh_rightwall;
-  }
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//coulomb interaction ion-leftwall///////////////////////////////////////////////////////////////////////////
-#pragma omp parallel default(shared) private(i, m, wall_dummy, fqq_leftwall, fqq_csh_leftwall, dz_leftwall, r1_leftwall, r2_leftwall, fcsh_inf_leftwall, fcsh_z_leftwall, temp_vec_leftwall)
-{
-#pragma omp for schedule(dynamic) nowait
+  #pragma omp for schedule(dynamic) nowait
     for (i = lowerBound; i <= upperBound; i++)
     {
-      fqq_leftwall = 0;
-      fqq_csh_leftwall = 0;
-      for (m = 0; m < box.leftplane.size(); m++)
-      {
-        wall_dummy = PARTICLE(0, 0, valency_counterion * -1, charge_meshpoint * 1.0, 0, box.eout, VECTOR3D(box.leftplane[m].posvec.x, box.leftplane[m].posvec.y, box.leftplane[m].posvec.z), box.lx, box.ly, box.lz);
+      fqq_rightwall = 0;
+      fqq_csh_rightwall = 0;
+      for (k = 0; k < box.rightplane.size(); k++) {
+        wall_dummy = PARTICLE(0, 0, valency_counterion * -1, charge_meshpoint * 1.0, 0, box.eout, VECTOR3D(box.rightplane[k].posvec.x, box.rightplane[k].posvec.y, box.rightplane[k].posvec.z), box.lx, box.ly, box.lz);
+        dz_rightwall  = ion[i].posvec.z - wall_dummy.posvec.z;
+        r1_rightwall = sqrt(0.5 + (dz_rightwall  / box.lx) * (dz_rightwall  / box.lx));
+        r2_rightwall = sqrt(0.25 + (dz_rightwall  / box.lx) * (dz_rightwall  / box.lx));
+        fcsh_z_rightwall = 4 * box.lx * log((0.5 + r1_rightwall) / r2_rightwall) - fabs(dz_rightwall) * (2 * pi - 4 * atan(4 * fabs(dz_rightwall ) * r1_rightwall / box.lx));
+        fcsh_inf_rightwall = -2 * pi * fabs(dz_rightwall);
+        fqq_csh_rightwall += ion[i].q * (wall_dummy.q / (box.lx * box.lx)) * 0.5 * (1 / ion[i].epsilon + 1 / wall_dummy.epsilon) * (fcsh_inf_rightwall - fcsh_z_rightwall);
 
-        dz_leftwall = ion[i].posvec.z - wall_dummy.posvec.z;
-        r1_leftwall = sqrt(0.5 + (dz_leftwall / box.lx) * (dz_leftwall / box.lx));
-        r2_leftwall = sqrt(0.25 + (dz_leftwall / box.lx) * (dz_leftwall / box.lx));
-        fcsh_z_leftwall = 4 * box.lx * log((0.5 + r1_leftwall) / r2_leftwall) - fabs(dz_leftwall) * (2 * pi - 4 * atan(4 * fabs(dz_leftwall) * r1_leftwall / box.lx));
-        fcsh_inf_leftwall = -2 * pi * fabs(dz_leftwall);
-        fqq_csh_leftwall += ion[i].q * (wall_dummy.q / (box.lx * box.lx)) * 0.5 * (1 / ion[i].epsilon + 1 / wall_dummy.epsilon) * (fcsh_inf_leftwall - fcsh_z_leftwall);
+        temp_vec_rightwall = ion[i].posvec - wall_dummy.posvec;
+        if (temp_vec_rightwall.x > box.lx / 2) temp_vec_rightwall.x -= box.lx;
+        if (temp_vec_rightwall.x < -box.lx / 2) temp_vec_rightwall.x += box.lx;
+        if (temp_vec_rightwall.y > box.ly / 2) temp_vec_rightwall.y -= box.ly;
+        if (temp_vec_rightwall.y < -box.ly / 2) temp_vec_rightwall.y += box.ly;
 
-        temp_vec_leftwall = ion[i].posvec - wall_dummy.posvec;
-        if (temp_vec_leftwall.x > box.lx / 2) temp_vec_leftwall.x -= box.lx;
-        if (temp_vec_leftwall.x < -box.lx / 2) temp_vec_leftwall.x += box.lx;
-        if (temp_vec_leftwall.y > box.ly / 2) temp_vec_leftwall.y -= box.ly;
-        if (temp_vec_leftwall.y < -box.ly / 2) temp_vec_leftwall.y += box.ly;
-        fqq_leftwall += ion[i].q * wall_dummy.q * 0.5 * (1.0 / ion[i].epsilon + 1.0 / wall_dummy.epsilon) / ((temp_vec_leftwall).GetMagnitude());
+        fqq_rightwall += ion[i].q * wall_dummy.q * 0.5 * (1.0 / ion[i].epsilon + 1.0 / wall_dummy.epsilon) / ((temp_vec_rightwall).GetMagnitude());
+
       }
-      coulomb_leftwall[i-lowerBound] = fqq_leftwall + fqq_csh_leftwall;
+      coulomb_rightwall[i-lowerBound] = fqq_rightwall + fqq_csh_rightwall;
     }
   }
 
-  // electrostatic interacting between right and left walls
-
-  double total_coulomb_between_walls = 0;
-  for (l = 0; l < box.rightplane.size(); l++)
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  //coulomb interaction ion-leftwall///////////////////////////////////////////////////////////////////////////
+  #pragma omp parallel default(shared) private(i, m, wall_dummy, fqq_leftwall, fqq_csh_leftwall, dz_leftwall, r1_leftwall, r2_leftwall, fcsh_inf_leftwall, fcsh_z_leftwall, temp_vec_leftwall)
   {
-    double fqq_walls = 0.0;
-    PARTICLE right_wall = PARTICLE(0, 0, valency_counterion * -1, charge_meshpoint * 1.0, 0, box.eout, VECTOR3D(box.rightplane[l].posvec.x, box.rightplane[l].posvec.y, box.rightplane[l].posvec.z), box.lx, box.ly, box.lz);
-    for (b = 0; b < box.leftplane.size(); b++)
-    {
-        if (l == b) continue;
-      PARTICLE left_wall = PARTICLE(0, 0, valency_counterion * -1, charge_meshpoint * 1.0, 0, box.eout, VECTOR3D(box.leftplane[b].posvec.x, box.leftplane[b].posvec.y, box.leftplane[b].posvec.z), box.lx, box.ly, box.lz);
+  #pragma omp for schedule(dynamic) nowait
+      for (i = lowerBound; i <= upperBound; i++)
+      {
+        fqq_leftwall = 0;
+        fqq_csh_leftwall = 0;
+        for (m = 0; m < box.leftplane.size(); m++)
+        {
+          wall_dummy = PARTICLE(0, 0, valency_counterion * -1, charge_meshpoint * 1.0, 0, box.eout, VECTOR3D(box.leftplane[m].posvec.x, box.leftplane[m].posvec.y, box.leftplane[m].posvec.z), box.lx, box.ly, box.lz);
 
-      VECTOR3D r_vec_walls = right_wall.posvec - left_wall.posvec;
-      fqq_walls = fqq_walls + 0.5 * right_wall.q * left_wall.q * 0.5 * (1.0 / right_wall.epsilon + 1.0 / left_wall.epsilon) / ((r_vec_walls).GetMagnitude());
-  }
-  total_coulomb_between_walls += fqq_walls;
+          dz_leftwall = ion[i].posvec.z - wall_dummy.posvec.z;
+          r1_leftwall = sqrt(0.5 + (dz_leftwall / box.lx) * (dz_leftwall / box.lx));
+          r2_leftwall = sqrt(0.25 + (dz_leftwall / box.lx) * (dz_leftwall / box.lx));
+          fcsh_z_leftwall = 4 * box.lx * log((0.5 + r1_leftwall) / r2_leftwall) - fabs(dz_leftwall) * (2 * pi - 4 * atan(4 * fabs(dz_leftwall) * r1_leftwall / box.lx));
+          fcsh_inf_leftwall = -2 * pi * fabs(dz_leftwall);
+          fqq_csh_leftwall += ion[i].q * (wall_dummy.q / (box.lx * box.lx)) * 0.5 * (1 / ion[i].epsilon + 1 / wall_dummy.epsilon) * (fcsh_inf_leftwall - fcsh_z_leftwall);
+
+          temp_vec_leftwall = ion[i].posvec - wall_dummy.posvec;
+          if (temp_vec_leftwall.x > box.lx / 2) temp_vec_leftwall.x -= box.lx;
+          if (temp_vec_leftwall.x < -box.lx / 2) temp_vec_leftwall.x += box.lx;
+          if (temp_vec_leftwall.y > box.ly / 2) temp_vec_leftwall.y -= box.ly;
+          if (temp_vec_leftwall.y < -box.ly / 2) temp_vec_leftwall.y += box.ly;
+          fqq_leftwall += ion[i].q * wall_dummy.q * 0.5 * (1.0 / ion[i].epsilon + 1.0 / wall_dummy.epsilon) / ((temp_vec_leftwall).GetMagnitude());
+        }
+        coulomb_leftwall[i-lowerBound] = fqq_leftwall + fqq_csh_leftwall;
+      }
+    }
 }
+
 
     double ion_ion = 0;
     double total_lj_ion_ion = 0;
@@ -312,7 +299,6 @@ long double energy_functional(vector <PARTICLE> &ion, INTERFACE &box, unsigned i
     double coulomb = (ion_ion) * scalefactor;    // scalefactor is there to ensure proper units; defined in utility.h
     total_coulomb_rightwall = (total_coulomb_rightwall) * scalefactor;
     total_coulomb_leftwall = (total_coulomb_leftwall) * scalefactor;
-    total_coulomb_between_walls = (total_coulomb_between_walls) * scalefactor;
 
     total_lj_ion_ion = 0.5 * total_lj_ion_ion;
     // factor of half for double counting, same reasoning as electrostatic energy
@@ -330,7 +316,8 @@ long double energy_functional(vector <PARTICLE> &ion, INTERFACE &box, unsigned i
         totalPotential=potential;
     }
 
-    totalPotential = totalPotential + total_coulomb_between_walls;
+    double total_electrostatics_between_walls = box.electrostatics_between_walls(charge_meshpoint);
+    totalPotential = totalPotential + total_electrostatics_between_walls;
 
     return totalPotential;
 }


### PR DESCRIPTION
@jadhao and @kadupitiya 
- The charge and epsilon are added to the properties of vertex. 
- The electrostatic interaction between the charged walls is calculated in interface.cpp, since it is a part of interface.
- An if condition is added in mdenergies.cpp, to skip the electrostatics calculations between ions and walls if there is no charge on the walls.