### PR TITLE
add NetChargeDensity_ScreenFactor function

### DIFF
--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -413,6 +413,7 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
             }
         }
     }
+    NetChargeDensity_ScreenFactor(charge_density, bin_width, simulationParams);
 
 
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -68,7 +68,7 @@ void auto_correlation_function();
 // generate LAMMPS input script
 void generateLammpsInputfileForChargedSurface(double , int , int , int , int, double, double, double);
 void generateLammpsInputfileForUnchargedSurface(double , int , int , int , int, double, double, double);
-
+void NetChargeDensity_ScreenFactor(double, double, string);
 
 // functions useful in computing forces and energies
 // -------------------------------------------------


### PR DESCRIPTION
@jadhao and @kadupitiya 

A function (NetChargeDensity_ScreenFactor) is added at the end of simulation (for both in-house and LAMMPS) to calculate net charge density & screen factor. The outputs will be in "data" folder.