### PR TITLE
Create "NetChargeDensity_ScreenFactor" function 

### DIFF
--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -413,7 +413,8 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
             }
         }
     }
-    NetChargeDensity_ScreenFactor(charge_density, bin_width, simulationParams);
+    
+    get_NetChargeDensity_ScreeningFactor(charge_density, bin_width, simulationParams);
 
 
 

--- a/src/NanoconfinementMd.cpp
+++ b/src/NanoconfinementMd.cpp
@@ -413,6 +413,7 @@ int NanoconfinementMd::startSimulation(int argc, char *argv[], bool paraMap) {
             }
         }
     }
+    NetChargeDensity_ScreenFactor(charge_density, bin_width, simulationParams);
 
 
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -675,7 +675,10 @@ void NetChargeDensity_ScreenFactor(double charge_density, double bin_width, stri
     //otherwis the "list_screencharge_profile" file is empty;
     if (charge_density != 0.0)
     {
-      list_screencharge_profile << bin_number << setw(15) << screenfactor_at_bin_number << endl;
+      if (bin_number <= 0.0)
+      { // we get the screening factor from left wall (-lz/2) to midplane (0);
+        list_screencharge_profile << bin_number << setw(15) << screenfactor_at_bin_number << endl;
+      }
     }
   }
   list_netcharge_profile.close();

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -645,7 +645,7 @@ void generateLammpsInputfileForUnchargedSurface(double ein, int Frequency, int s
 
 }
 
-void NetChargeDensity_ScreenFactor(double charge_density, double bin_width, string simulationParams)
+void get_NetChargeDensity_ScreeningFactor(double charge_density, double bin_width, string simulationParams)
 {
   string netcharge_density_profile, screen_factor_profile, errorbars;
   double bin_number, p_density_at_bin_number, n_density_at_bin_number;

--- a/src/functions.h
+++ b/src/functions.h
@@ -68,7 +68,7 @@ void auto_correlation_function();
 // generate LAMMPS input script
 void generateLammpsInputfileForChargedSurface(double , int , int , int , int, double, double, double);
 void generateLammpsInputfileForUnchargedSurface(double , int , int , int , int, double, double, double);
-
+void NetChargeDensity_ScreenFactor(double, double, string);
 
 // functions useful in computing forces and energies
 // -------------------------------------------------

--- a/src/functions.h
+++ b/src/functions.h
@@ -68,7 +68,7 @@ void auto_correlation_function();
 // generate LAMMPS input script
 void generateLammpsInputfileForChargedSurface(double , int , int , int , int, double, double, double);
 void generateLammpsInputfileForUnchargedSurface(double , int , int , int , int, double, double, double);
-void NetChargeDensity_ScreenFactor(double, double, string);
+void get_NetChargeDensity_ScreeningFactor(double, double, string);
 
 // functions useful in computing forces and energies
 // -------------------------------------------------


### PR DESCRIPTION
@jadhao and @kadupitiya

A function (NetChargeDensity_ScreenFactor) is added at the end of simulation (for both in-house and LAMMPS) to calculate net charge density & screen factor. The outputs are "screen_factor_profile.dat" and " netcharge_density_profile" in "data" folder.